### PR TITLE
Make posts site at top level

### DIFF
--- a/_posts/2015-04-05-stoop-our-first-open-source-release.md
+++ b/_posts/2015-04-05-stoop-our-first-open-source-release.md
@@ -3,7 +3,6 @@ layout: post
 title: "Stoop: our first open source release"
 subtitle: "A Scala DSL for interfacing with CouchDB"
 header-img: "img/mon-field_rows.jpg"
-category: code
 tags: [open source, scala, couchdb]
 ---
 

--- a/_posts/2015-04-06-we-are-monsanto-engineering.md
+++ b/_posts/2015-04-06-we-are-monsanto-engineering.md
@@ -3,7 +3,6 @@ layout: post
 title: "We are Monsanto Engineering"
 subtitle: "Our Diversity of IT Innovation"
 header-img: "img/mon-field_rows.jpg"
-category: code
 tags: [open source, introduction, overview]
 ---
 


### PR DESCRIPTION
_posts: remove category Jekyll YAML front matter so posts sit at top level

This change is per our discussion in the Slack eng-blog channel. The posts will be relative to the top level, not under a category.
