### PR TITLE
pathing issue in docs for calling the readme

### DIFF
--- a/_posts/2015-07-08-stax.md
+++ b/_posts/2015-07-08-stax.md
@@ -128,8 +128,8 @@ For more help, check the docs: https://github.com/MonsantoCo/stax
 To try it out, just clone the repo and follow the documentation in the readme.
 
 ```
-$ git clone https://github.com/MonsantoCo/stax
-$ more README.md
+git clone https://github.com/MonsantoCo/stax
+more stax/README.md
 ```
 
 We hope that this tool will be useful to the community and look forward to feedback on what people think of it. We’re open to issues you might create or pull requests to make stax better.


### PR DESCRIPTION
I also took out the '$' in the text, since I never put those in where I expect someone might cut/paste from it, but I left 'more' in there, I would have used 'less'. Probably not the best way, but from habit it's how I would wrote it.