### PR TITLE
added a new careers page with a sample jobs.json data

### DIFF
--- a/_data/jobs.json
+++ b/_data/jobs.json
@@ -1,0 +1,33 @@
+[
+  {
+    "id":"014WV",
+    "title":"Customer analytics",
+    "location":"Saint Louis, MO",
+    "description":"Monsanto has built an industry-leading Big Data Platform to transform domains as diverse as genomics to precision agriculture.  We are looking for a Big Data Engineer to help drive the growth of this platform as we pursue our mission of feeding the world while conserving resources and improving lives"
+  },
+  {
+    "id":"01489",
+    "title":"Placement Data Analyst",
+    "location":"Saint Louis, MO",
+    "description":"This is an exciting opportunity for a talented and passionate individual to join a multidisciplinary team of Data Scientists and Engineers who work on real world problems. In this role you will be responsible for conducting complex, high profile data analyses relevant to the agricultural industry, including but not limited to soft commodities. "
+  },
+  {
+    "id":"0158I",
+    "title":"ASL Laborant",
+    "location":"Saint Louis, MO",
+    "description":"The Monsanto Information Security Office seeks an Information Security Intelligence Analyst to join its dynamic and high-performing Cyber Threat and Intelligence team. The successful candidate will have the ability to learn and utilize cutting edge technology and techniques while working in both an individual and group environment. The candidate will serve as an intelligence analyst in a growing and developing intelligence function within the Information Security Office. This position requires a highly motivated individual who will relish researching cyber threats while working to improve the organizations visibility and responsiveness to information security threats."
+  },
+  {
+    "id":"00ZLK",
+    "title":"HR Generalist CES",
+    "location":"Saint Louis, MO",
+    "description":"Monsanto has built an industry-leading Big Data Platform to transform domains as diverse as genomics to precision agriculture.  We are looking for a Big Data Engineer to help drive the growth of this platform as we pursue our mission of feeding the world while conserving resources and improving lives"
+
+  },
+  {
+    "id":"014EE",
+    "title":"Process Control Systems Engineer",
+    "location":"Saint Louis, MO",
+    "description":"Monsanto has built an industry-leading Big Data Platform to transform domains as diverse as genomics to precision agriculture.  We are looking for a Big Data Engineer to help drive the growth of this platform as we pursue our mission of feeding the world while conserving resources and improving lives"
+  }
+]

--- a/careers.html
+++ b/careers.html
@@ -31,7 +31,7 @@ header-img: "img/mon-woodlands.jpg"
     <hr/>
 
     <div class='row'>
-        <div class="col-md-12"><a class="btn btn-primary col-md-12" href="https://jobs.monsanto.com/category/information-technology-jobs/769/2669/1"> <span class="glyphicon glyphicon-search"> </span> <span class="btn-txt">Search for open positions</span></a></div>
+        <div class="col-md-12"><a class="btn btn-primary col-md-12" href="https://jobs.monsanto.com/it-engineering"> <span class="glyphicon glyphicon-search"> </span> <span class="btn-txt">Search for open positions</span></a></div>
         <div class="col-md-12"><em style="font-size: small" class="text-info">Note: The search will redirect to our jobs portal</em></div>
     </div>
 

--- a/careers.html
+++ b/careers.html
@@ -18,15 +18,14 @@ header-img: "img/mon-woodlands.jpg"
 <div class='container-fluid'>
     <div class='row'>
         <div class='col-md-12'>
-            At Monsanto, you will work with other top level talent solving a wide range of complex and unique challenges
-            that have real-world impact. You can help feed, clothe and fuel a growing population through ground-breaking innovation. Ready to do your part?
+            We at Monsanto are more than 20,000 employees dedicated to contributing to a smarter way to feed the world. Making a balanced meal accessible to everyone, and doing it in a sustainable way, requires a wide range of ideas and resources. At Monsanto you will find a team-focused environment that thrives on innovation and encourages you to do extraordinary things. We know that every day, new ideas can come from anyone, anywhere. By incorporating cutting-edge technology and your experience, you will push the limits of agricultural technology and help change the world. Are you ready to begin?
         </div>
     </div>
     <br/>
 
     <div class='row'>
         <div class='col-md-12'>
-            {% youtube nyAP1xmgur0 %}
+            {% youtube M9Xxxc95hrE %}
         </div>
     </div>
     <hr/>

--- a/careers.html
+++ b/careers.html
@@ -1,0 +1,45 @@
+---
+layout: page
+title: "Careers"
+description: "Help us change the world"
+header-img: "img/mon-woodlands.jpg"
+---
+<link rel="stylesheet" href="/css/styles.css">
+<link rel="stylesheet" href="/css/font-awesome.css">
+
+<div class='container-fluid'>
+    <div class='row'>
+        <div class='col-md-12'>
+            At Monsanto, you will work with other top level talent solving a wide range of complex and unique challenges
+            that have real-world impact. You can help feed, clothe and fuel a growing population through ground-breaking innovation. Ready to do your part?
+        </div>
+    </div>
+    <br/>
+
+    <div class='row'>
+        <div class='col-md-12'>
+            {% youtube nyAP1xmgur0 %}
+        </div>
+    </div>
+    <hr/>
+    <h1 style="text-align: center">Jobs</h1>
+
+    <div class='row'>
+        {% for job in site.data.jobs %}
+        <div class='col-md-6'>
+            <div class="panel panel-default">
+                <div class="panel-heading">{{job.title}}</div>
+                <div class="panel-body">
+                    <span style="font-size: 16px;">{{job.description}}</span>
+                </div>
+                <div class="panel-footer">
+                  <span style="font-size: 14px;">{{job.location}}</span>
+                  <span style="font-size: 14px;"><a href="https://monsanto.taleo.net/careersection/2/jobdetail.ftl?job={{job.id}}" class="label label-primary pull-right" target="_blank" title="Apply Now" style="margin-top: 5px;"> Apply Now </a></span>
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+</div>
+

--- a/careers.html
+++ b/careers.html
@@ -6,7 +6,15 @@ header-img: "img/mon-woodlands.jpg"
 ---
 <link rel="stylesheet" href="/css/styles.css">
 <link rel="stylesheet" href="/css/font-awesome.css">
-
+<style>
+    .glyphicon.glyphicon-search {
+        font-size: 25px;
+    }
+    .btn-txt{
+        text-transform: none;
+        font-size: 20px;
+    }
+</style>
 <div class='container-fluid'>
     <div class='row'>
         <div class='col-md-12'>
@@ -22,24 +30,10 @@ header-img: "img/mon-woodlands.jpg"
         </div>
     </div>
     <hr/>
-    <h1 style="text-align: center">Jobs</h1>
 
     <div class='row'>
-        {% for job in site.data.jobs %}
-        <div class='col-md-6'>
-            <div class="panel panel-default">
-                <div class="panel-heading">{{job.title}}</div>
-                <div class="panel-body">
-                    <span style="font-size: 16px;">{{job.description}}</span>
-                </div>
-                <div class="panel-footer">
-                  <span style="font-size: 14px;">{{job.location}}</span>
-                  <span style="font-size: 14px;"><a href="https://monsanto.taleo.net/careersection/2/jobdetail.ftl?job={{job.id}}" class="label label-primary pull-right" target="_blank" title="Apply Now" style="margin-top: 5px;"> Apply Now </a></span>
-                </div>
-            </div>
-        </div>
-        {% endfor %}
+        <div class="col-md-12"><a class="btn btn-primary col-md-12" href="https://jobs.monsanto.com/category/information-technology-jobs/769/2669/1"> <span class="glyphicon glyphicon-search"> </span> <span class="btn-txt">Search for open positions</span></a></div>
+        <div class="col-md-12"><em style="font-size: small" class="text-info">Note: The search will redirect to our jobs portal</em></div>
     </div>
 
 </div>
-


### PR DESCRIPTION
This is the first cut at the proposed careers page. It uses a local jobs.json which can be manually edited to get the jobs listing updated on the blog. The current listings in the jobs.json is mocked up. 

This pull request is for review purpose only and to identify if any changes are desired, please do not merge and release it yet as we have to wait on David Carter/ Stephanie Bahr with the go ahead for releasing this feature.